### PR TITLE
Adding isStable parameter to the getHealthFactor method on the MarketLens.

### DIFF
--- a/script/MarketLens.s.sol
+++ b/script/MarketLens.s.sol
@@ -8,7 +8,7 @@ contract MarketLensScript is BaseScript {
     function run() public returns (MarketLens lens) {
         startBroadcast();
 
-        lens = new MarketLens{salt: bytes32(bytes("MarketLens.s.sol-20230316-v5"))}();
+        lens = new MarketLens{salt: bytes32(bytes("MarketLens.s.sol-20230406-v6"))}();
 
         stopBroadcast();
     }

--- a/src/lenses/MarketLens.sol
+++ b/src/lenses/MarketLens.sol
@@ -138,8 +138,9 @@ contract MarketLens {
         (ltvBps, , , , , ) = CauldronLib.getUserPositionInfo(cauldron, account);
     }
 
-    function getHealthFactor(ICauldronV2 cauldron, address account) public view returns (uint256 healthFactor) {
-        (, healthFactor, , , , ) = CauldronLib.getUserPositionInfo(cauldron, account);
+    function getHealthFactor(ICauldronV2 cauldron, address account, bool isStable) public view returns (uint256) {
+        (, uint256 healthFactor, , , , ) = CauldronLib.getUserPositionInfo(cauldron, account);
+        return isStable ? healthFactor * 10 : healthFactor;
     }
 
     function getUserLiquidationPrice(ICauldronV2 cauldron, address account) public view returns (uint256 liquidationPrice) {

--- a/test/MarketLens.t.sol
+++ b/test/MarketLens.t.sol
@@ -134,8 +134,20 @@ contract MarketLensTest is BaseTest {
 
     function testGetHealthFactor() public {
         address cauldronAddress = constants.cauldronAddressMap("mainnet", "Stargate-USDT", 3);
-        uint256 response = lens.getHealthFactor(ICauldronV3(cauldronAddress), 0x1e121993b4A8bC79D18A4C409dB84c100FFf25F5);
+        uint256 response = lens.getHealthFactor(ICauldronV3(cauldronAddress), 0x1e121993b4A8bC79D18A4C409dB84c100FFf25F5, false);
         assertEq(response, 19542661960000000);
+    }
+
+    function testGetHealthFactorForStable() public {
+        address cauldronAddress = constants.cauldronAddressMap("mainnet", "Stargate-USDT", 3);
+        uint256 response = lens.getHealthFactor(ICauldronV3(cauldronAddress), 0x1e121993b4A8bC79D18A4C409dB84c100FFf25F5, true);
+        assertEq(response, 195426619600000000);
+    }
+
+    function testGetHealthFactorForVolatile() public {
+        address cauldronAddress = constants.cauldronAddressMap("mainnet", "WBTC", 4);
+        uint256 response = lens.getHealthFactor(ICauldronV3(cauldronAddress), 0x8a2Ec1337217Dc52de95230a2979A408E7B4D78E, false);
+        assertEq(response, 533905941397697800);
     }
 
     function testGetUserLiquidationPrice() public {


### PR DESCRIPTION
This is required for HAL notifications. HealthFactor for stablepools are multiplied by 10 and this logic cannot be done on the HAL engine side, so I updated the contract to take in an extra isStable parameter.

ClickUp Ticket: https://app.clickup.com/t/8669tjytx