### PR TITLE
🐞 Fix LogBorrow in PrivilegedCauldronV4

### DIFF
--- a/src/cauldrons/PrivilegedCauldronV4.sol
+++ b/src/cauldrons/PrivilegedCauldronV4.sol
@@ -17,7 +17,7 @@ contract PrivilegedCauldronV4 is CauldronV4 {
 
         userBorrowPart[to] = userBorrowPart[to] + part;
 
-        emit LogBorrow(msg.sender, to, amount, part);
+        emit LogBorrow(to, to, amount, part);
 
         require(_isSolvent(to, exchangeRate), "Cauldron: user insolvent");
     }


### PR DESCRIPTION
Could also consider making a specific event for this. Like `LogAddPosition`, but before it was implemented in a way s.t. `msg.sender` was considered the on who was borrowed from. The `to` (second parameter) in `LogBorrow` doesn't make much sense for `addPosition`, as the debt is just added directly to the user's position, and no MIMs are transferred.