### PR TITLE
🚀 Add available skim to MarketLens

### DIFF
--- a/src/lenses/MarketLens.sol
+++ b/src/lenses/MarketLens.sol
@@ -9,6 +9,8 @@ import {MathLib} from "/libraries/MathLib.sol";
 import {CauldronLib} from "/libraries/CauldronLib.sol";
 
 contract MarketLens {
+    using CauldronLib for ICauldronV2;
+
     struct UserPosition {
         address cauldron;
         address account;
@@ -199,5 +201,18 @@ contract MarketLens {
         marketInfo = getMarketInfoCauldronV2(cauldron);
         marketInfo.marketMaxBorrow = getMaxMarketBorrowForCauldronV3(cauldron);
         marketInfo.userMaxBorrow = getMaxUserBorrowForCauldronV3(cauldron);
+    }
+
+    /// @notice Get the available skim amount for the caller cauldron.
+    /// Designed for use as a call action in `cook`. Typically followed
+    /// by an add collateral action that skims available amount of shares.
+    function availableSkim() public view returns (uint256 share) {
+        // Assume caller is a cauldron
+        return ICauldronV2(msg.sender).getAvailableSkim();
+    }
+
+    /// @notice Get the available skim amount for the cauldron.
+    function availableSkim(ICauldronV2 cauldron) public view returns (uint256 share) {
+        return cauldron.getAvailableSkim();
     }
 }

--- a/src/libraries/CauldronLib.sol
+++ b/src/libraries/CauldronLib.sol
@@ -198,6 +198,10 @@ library CauldronLib {
         return (collateralPrecision * collateralPrecision) / getOracleExchangeRate(cauldron);
     }
 
+    function getAvailableSkim(ICauldronV2 cauldron) internal view returns (uint256) {
+        return IBentoBoxV1(cauldron.bentoBox()).balanceOf(IERC20(cauldron.collateral()), msg.sender) - cauldron.totalCollateralShare();
+    }
+
     function decodeInitData(
         bytes calldata data
     )


### PR DESCRIPTION
Designed for use in `cook` calls where an unknown amount of shares have been deposited directly to the cauldron (i.e. is skimmable) in an earlier action. The helper just returns the amount of shares that can be skimmed. Typically this will be used to the amount of shares as collateral in a subsequent action.